### PR TITLE
Restore TLS verification for Google sync client

### DIFF
--- a/application/libraries/Google_sync.php
+++ b/application/libraries/Google_sync.php
@@ -61,9 +61,7 @@ class Google_sync
      */
     public function initialize_clients(): void
     {
-        $http = new GuzzleHttp\Client([
-            'verify' => false,
-        ]);
+        $http = new GuzzleHttp\Client();
 
         $this->client = new Google_Client();
         $this->client->setHttpClient($http);


### PR DESCRIPTION
## Summary
- stop disabling TLS certificate verification for the Google sync Guzzle client so that secure defaults apply

## Testing
- `composer test` *(fails: Could not open input file: vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f7fd88d48333be744d5981653132